### PR TITLE
feat: GET cocktail list view

### DIFF
--- a/backend/qualla/cocktail/serializers.py
+++ b/backend/qualla/cocktail/serializers.py
@@ -21,3 +21,7 @@ class CocktailListSerializer(serializers.ModelSerializer):
 
     def get_tags(self, obj):
         return ["this", "is", "so", "delicious"]
+
+class CustomCocktailListSerializer(CocktailListSerializer):
+    class Meta(CocktailListSerializer.Meta):
+        fields=CocktailListSerializer.Meta.fields + ('author_id',)

--- a/backend/qualla/cocktail/urls.py
+++ b/backend/qualla/cocktail/urls.py
@@ -1,0 +1,7 @@
+from django import views
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.cocktail_list, name='cocktail list')
+]

--- a/backend/qualla/cocktail/views.py
+++ b/backend/qualla/cocktail/views.py
@@ -1,3 +1,19 @@
-from django.shortcuts import render
+from django.http import HttpResponseBadRequest, HttpResponseNotAllowed, JsonResponse
+from .models import Cocktail
+from .serializers import CocktailListSerializer, CustomCocktailListSerializer
 
-# Create your views here.
+def cocktail_list(request):
+    if request.method == 'GET':
+        type = request.GET.get('type')
+        if type == 'standard':
+            standard_cocktails = Cocktail.objects.filter(type='ST')
+            data = CocktailListSerializer(standard_cocktails, many=True).data
+            return JsonResponse({"cocktails": data, "count": standard_cocktails.count()}, safe=False)
+        elif type == 'custom':
+            custom_cocktails = Cocktail.objects.filter(type='CS')
+            data = CustomCocktailListSerializer(custom_cocktails, many=True).data
+            return JsonResponse({"cocktails": data, "count": custom_cocktails.count()}, safe=False)
+        else:
+            return HttpResponseBadRequest('Cocktail type is needed!')
+    else:
+        return HttpResponseNotAllowed(['GET', 'POST'])

--- a/backend/qualla/qualla/urls.py
+++ b/backend/qualla/qualla/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
+    path('api/v1/cocktails', include('cocktail.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
    - custom과 standard의 구분을 위하여 query param 사용
    - GET /api/v1/cocktails?type=standard or custom

Resolves #3 
## 해결/개선하고자 한 기능 설명
cocktail 리스트 뷰

## 실제로 해결/개선한 방식
메인페이지에 보일 정보이기 때문에 serialize에 적힌 attribute 들만 가져옴,
태그, 유저 아이디, 이미지는 더미데이터로 하드코딩

## 나중에 추가로 해결/개선해야하는 사항
위의 더미데이터 타입 바꾸기, csrf 설정하기, 뷰셋으로 리팩토링하기
